### PR TITLE
Add simple time tracking app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # gpt
 aplicaciones creadas para gpt
+
+## Aplicación de imputación de tiempos
+
+Esta aplicación web permite seleccionar clientes y tareas, registrar el inicio y fin de cada actividad y generar reportes por día. Los reportes pueden exportarse a Excel.
+
+### Requisitos
+- Python 3
+- pip
+
+### Instalación
+```
+pip install -r requirements.txt
+```
+
+### Uso
+```
+python app.py
+```
+La aplicación se iniciará en `http://localhost:5000`.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,127 @@
+from flask import Flask, render_template, request, redirect, url_for, send_file
+import sqlite3
+from datetime import datetime
+import pandas as pd
+import io
+
+app = Flask(__name__)
+DATABASE = 'database.db'
+
+
+def get_db():
+    return sqlite3.connect(DATABASE)
+
+
+def init_db():
+    with get_db() as conn:
+        conn.execute('CREATE TABLE IF NOT EXISTS clients (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)')
+        conn.execute('CREATE TABLE IF NOT EXISTS tasks (id INTEGER PRIMARY KEY AUTOINCREMENT, client_id INTEGER, name TEXT, status TEXT)')
+        conn.execute('CREATE TABLE IF NOT EXISTS time_entries (id INTEGER PRIMARY KEY AUTOINCREMENT, client_id INTEGER, task_id INTEGER, start_time TEXT, end_time TEXT)')
+        # Datos de ejemplo si las tablas estan vacias
+        if conn.execute('SELECT COUNT(*) FROM clients').fetchone()[0] == 0:
+            conn.execute('INSERT INTO clients (name) VALUES (?)', ('Cliente A',))
+            conn.execute('INSERT INTO clients (name) VALUES (?)', ('Cliente B',))
+        if conn.execute('SELECT COUNT(*) FROM tasks').fetchone()[0] == 0:
+            conn.execute('INSERT INTO tasks (client_id, name, status) VALUES (1, "Tarea 1", "open")')
+            conn.execute('INSERT INTO tasks (client_id, name, status) VALUES (1, "Tarea 2", "open")')
+            conn.execute('INSERT INTO tasks (client_id, name, status) VALUES (2, "Tarea 1", "open")')
+        conn.commit()
+
+
+@app.before_first_request
+def setup():
+    init_db()
+
+
+@app.route('/', methods=['GET'])
+def index():
+    conn = get_db()
+    clients = conn.execute('SELECT id, name FROM clients').fetchall()
+    selected_client = request.args.get('client_id')
+    tasks = []
+    if selected_client:
+        tasks = conn.execute(
+            'SELECT id, name FROM tasks WHERE client_id=? AND status="open"',
+            (selected_client,)
+        ).fetchall()
+    running_entry = conn.execute(
+        'SELECT id, client_id, task_id FROM time_entries WHERE end_time IS NULL'
+    ).fetchone()
+    conn.close()
+    return render_template(
+        'index.html',
+        clients=clients,
+        tasks=tasks,
+        selected_client=selected_client,
+        running_entry=running_entry,
+    )
+
+
+@app.route('/start', methods=['POST'])
+def start():
+    client_id = request.form['client_id']
+    task_id = request.form['task_id']
+    now = datetime.now().isoformat(timespec='seconds')
+    with get_db() as conn:
+        conn.execute(
+            'INSERT INTO time_entries (client_id, task_id, start_time) VALUES (?, ?, ?)',
+            (client_id, task_id, now),
+        )
+        conn.commit()
+    return redirect(url_for('index', client_id=client_id))
+
+
+@app.route('/stop', methods=['POST'])
+def stop():
+    now = datetime.now().isoformat(timespec='seconds')
+    with get_db() as conn:
+        entry = conn.execute(
+            'SELECT id FROM time_entries WHERE end_time IS NULL ORDER BY start_time DESC LIMIT 1'
+        ).fetchone()
+        if entry:
+            conn.execute('UPDATE time_entries SET end_time=? WHERE id=?', (now, entry[0]))
+            conn.commit()
+    return redirect(url_for('index'))
+
+
+@app.route('/report')
+def report():
+    date = request.args.get('date')
+    query = (
+        'SELECT t.start_time, t.end_time, c.name as client, ta.name as task '
+        'FROM time_entries t '
+        'JOIN clients c ON t.client_id=c.id '
+        'JOIN tasks ta ON t.task_id=ta.id'
+    )
+    params = []
+    if date:
+        query += ' WHERE date(t.start_time)=?'
+        params.append(date)
+    with get_db() as conn:
+        entries = conn.execute(query, params).fetchall()
+    return render_template('report.html', entries=entries, date=date)
+
+
+@app.route('/export')
+def export():
+    date = request.args.get('date')
+    query = (
+        'SELECT t.start_time, t.end_time, c.name as client, ta.name as task '
+        'FROM time_entries t '
+        'JOIN clients c ON t.client_id=c.id '
+        'JOIN tasks ta ON t.task_id=ta.id'
+    )
+    params = []
+    if date:
+        query += ' WHERE date(t.start_time)=?'
+        params.append(date)
+    with get_db() as conn:
+        df = pd.read_sql_query(query, conn, params=params)
+    output = io.BytesIO()
+    df.to_excel(output, index=False)
+    output.seek(0)
+    return send_file(output, download_name='reporte.xlsx', as_attachment=True)
+
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+pandas
+openpyxl

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Imputaci&oacute;n de tiempos</title>
+  </head>
+  <body>
+    <h1>Imputaci&oacute;n de tiempos</h1>
+    <form method="get" action="/">
+      <label>Cliente:</label>
+      <select name="client_id" onchange="this.form.submit()">
+        <option value="">--Seleccione cliente--</option>
+        {% for c in clients %}
+          <option value="{{c[0]}}" {% if selected_client and c[0]==int(selected_client) %}selected{% endif %}>{{c[1]}}</option>
+        {% endfor %}
+      </select>
+    </form>
+
+    {% if selected_client %}
+    <form method="post" action="/start">
+      <input type="hidden" name="client_id" value="{{selected_client}}">
+      <label>Tarea:</label>
+      <select name="task_id">
+        {% for t in tasks %}
+          <option value="{{t[0]}}">{{t[1]}}</option>
+        {% endfor %}
+      </select>
+      <button type="submit">Inicio</button>
+    </form>
+    {% endif %}
+
+    {% if running_entry %}
+    <form method="post" action="/stop">
+      <button type="submit">Fin</button>
+    </form>
+    {% endif %}
+
+    <a href="{{ url_for('report') }}">Ver reportes</a>
+  </body>
+</html>

--- a/templates/report.html
+++ b/templates/report.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Reporte</title>
+  </head>
+  <body>
+    <h1>Reporte</h1>
+    <form method="get" action="/report">
+      <label>Fecha:</label>
+      <input type="date" name="date" value="{{date}}">
+      <button type="submit">Filtrar</button>
+    </form>
+    <table border="1">
+      <tr><th>Inicio</th><th>Fin</th><th>Cliente</th><th>Tarea</th></tr>
+      {% for e in entries %}
+      <tr>
+        <td>{{e[0]}}</td>
+        <td>{{e[1]}}</td>
+        <td>{{e[2]}}</td>
+        <td>{{e[3]}}</td>
+      </tr>
+      {% endfor %}
+    </table>
+    <a href="{{ url_for('export', date=date) }}">Exportar a Excel</a> |
+    <a href="{{ url_for('index') }}">Volver</a>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement a Flask app with a SQLite database for clients, tasks and time entries
- create templates to select clients and tasks, start/stop timers, and list reports
- allow exporting reports to Excel
- document usage

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6883d2ea8508832299780fd569991c78